### PR TITLE
Remove unused IDisposable array

### DIFF
--- a/src/jsonMode.ts
+++ b/src/jsonMode.ts
@@ -12,14 +12,10 @@ import {createTokenizationSupport} from './tokenization';
 
 import Promise = monaco.Promise;
 import Uri = monaco.Uri;
-import IDisposable = monaco.IDisposable;
 
 export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
 
-	let disposables: IDisposable[] = [];
-
 	const client = new WorkerManager(defaults);
-	disposables.push(client);
 
 	const worker: languageFeatures.WorkerAccessor = (...uris: Uri[]): Promise<JSONWorker> => {
 		return client.getLanguageServiceWorker(...uris);
@@ -27,14 +23,14 @@ export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
 
 	let languageId = defaults.languageId;
 
-	disposables.push(monaco.languages.registerCompletionItemProvider(languageId, new languageFeatures.CompletionAdapter(worker)));
-	disposables.push(monaco.languages.registerHoverProvider(languageId, new languageFeatures.HoverAdapter(worker)));
-	disposables.push(monaco.languages.registerDocumentSymbolProvider(languageId, new languageFeatures.DocumentSymbolAdapter(worker)));
-	disposables.push(monaco.languages.registerDocumentFormattingEditProvider(languageId, new languageFeatures.DocumentFormattingEditProvider(worker)));
-	disposables.push(monaco.languages.registerDocumentRangeFormattingEditProvider(languageId, new languageFeatures.DocumentRangeFormattingEditProvider(worker)));
-	disposables.push(new languageFeatures.DiagnostcsAdapter(languageId, worker));
-	disposables.push(monaco.languages.setTokensProvider(languageId, createTokenizationSupport(true)));
-	disposables.push(monaco.languages.setLanguageConfiguration(languageId, richEditConfiguration));
+	monaco.languages.registerCompletionItemProvider(languageId, new languageFeatures.CompletionAdapter(worker));
+	monaco.languages.registerHoverProvider(languageId, new languageFeatures.HoverAdapter(worker));
+	monaco.languages.registerDocumentSymbolProvider(languageId, new languageFeatures.DocumentSymbolAdapter(worker));
+	monaco.languages.registerDocumentFormattingEditProvider(languageId, new languageFeatures.DocumentFormattingEditProvider(worker));
+	monaco.languages.registerDocumentRangeFormattingEditProvider(languageId, new languageFeatures.DocumentRangeFormattingEditProvider(worker));
+	new languageFeatures.DiagnostcsAdapter(languageId, worker);
+	monaco.languages.setTokensProvider(languageId, createTokenizationSupport(true));
+	monaco.languages.setLanguageConfiguration(languageId, richEditConfiguration);
 }
 
 


### PR DESCRIPTION
There is an `IDisposable[]` that gets created in `jsonMode.ts` but it doesn't seem to serve any purpose. It should be removed instead.

See Microsoft/monaco-editor#738.